### PR TITLE
Restrict seconds selection to predefined options

### DIFF
--- a/public/app.js
+++ b/public/app.js
@@ -267,7 +267,7 @@ async function handleFormSubmit(event) {
     prompt: elements.prompt.value,
     model: elements.model.value,
     size: elements.size.value,
-    seconds: Number(elements.seconds.value),
+    seconds: elements.seconds.value,
   };
 
   try {

--- a/public/index.html
+++ b/public/index.html
@@ -42,7 +42,11 @@
           <div class="field-grid">
             <div class="field">
               <label for="seconds">長さ（秒）</label>
-              <input type="number" id="seconds" name="seconds" min="1" max="120" value="4" required />
+              <select id="seconds" name="seconds" required>
+                <option value="4">4 秒</option>
+                <option value="8">8 秒</option>
+                <option value="12">12 秒</option>
+              </select>
             </div>
             <div class="field">
               <label for="input_reference">参照メディア（任意）</label>

--- a/server.js
+++ b/server.js
@@ -80,7 +80,13 @@ function sanitizeVideoParams(params) {
   const prompt = params.prompt;
   const model = params.model ?? 'sora-2';
   const size = (params.size || params.resolution || '720x1280');
-  const seconds = (params.seconds != null ? params.seconds : (params.durationSeconds != null ? params.durationSeconds : 4));
+  const rawSeconds =
+    params.seconds != null
+      ? params.seconds
+      : params.durationSeconds != null
+        ? params.durationSeconds
+        : '4';
+  const seconds = typeof rawSeconds === 'string' ? rawSeconds : String(rawSeconds);
 
   if (!prompt || typeof prompt !== 'string' || !prompt.trim()) {
     errors.push('prompt is required');
@@ -93,9 +99,9 @@ function sanitizeVideoParams(params) {
   if (!sizePattern.test(size)) {
     errors.push('size must follow WIDTHxHEIGHT');
   }
-  const secondsNumber = Number(seconds);
-  if (!Number.isFinite(secondsNumber) || secondsNumber <= 0 || secondsNumber > 120) {
-    errors.push('seconds must be between 1 and 120');
+  const allowedSeconds = ['4', '8', '12'];
+  if (!allowedSeconds.includes(seconds)) {
+    errors.push('seconds must be one of 4, 8, 12');
   }
 
   return {
@@ -103,7 +109,7 @@ function sanitizeVideoParams(params) {
     prompt: prompt ? prompt.trim() : '',
     model,
     size,
-    seconds: secondsNumber,
+    seconds,
   };
 }
 


### PR DESCRIPTION
## Summary
- replace the seconds input with a select that only offers 4, 8, or 12 seconds
- keep the seconds value as a string on the client and server when sending requests
- validate that the requested seconds matches the allowed options before calling OpenAI

## Testing
- not run


------
https://chatgpt.com/codex/tasks/task_e_68e4e2bbca2483289a016bfde1e666dd