### PR TITLE
Restrict video resolutions to supported set

### DIFF
--- a/README.md
+++ b/README.md
@@ -75,7 +75,7 @@
 - `prompt`: 生成プロンプト。
 - `seconds`: 生成秒数。必要に応じて外部 API 送信時に `duration` へマッピング。
  - `seconds`: 生成秒数。外部 API にも `seconds` として送信。
-- `size`: 出力解像度（例: `1920x1080`）。
+- `size`: 出力解像度（`720x1280` / `1280x720` / `1024x1792` / `1792x1024`）。
 - `input_reference?`: 参照する画像/動画のメタ情報または格納先（任意）。
 - `cost_estimate_usd`: コスト目安（任意）。
 - `created_at`, `updated_at`。

--- a/public/index.html
+++ b/public/index.html
@@ -34,8 +34,8 @@
               <select id="size" name="size">
                 <option value="720x1280">720 x 1280</option>
                 <option value="1280x720">1280 x 720</option>
-                <option value="1920x1080">1920 x 1080</option>
-                <option value="3840x2160">3840 x 2160</option>
+                <option value="1024x1792">1024 x 1792</option>
+                <option value="1792x1024">1792 x 1024</option>
               </select>
             </div>
           </div>

--- a/server.js
+++ b/server.js
@@ -79,7 +79,8 @@ function sanitizeVideoParams(params) {
   // 後方互換のため旧フィールド名を新フィールドへマップ
   const prompt = params.prompt;
   const model = params.model ?? 'sora-2';
-  const size = (params.size || params.resolution || '720x1280');
+  const allowedSizes = ['720x1280', '1280x720', '1024x1792', '1792x1024'];
+  const size = params.size || params.resolution || allowedSizes[0];
   const seconds = (params.seconds != null ? params.seconds : (params.durationSeconds != null ? params.durationSeconds : 4));
 
   if (!prompt || typeof prompt !== 'string' || !prompt.trim()) {
@@ -89,9 +90,8 @@ function sanitizeVideoParams(params) {
   if (!allowedModels.includes(model)) {
     errors.push('model must be one of sora-2, sora-2-pro');
   }
-  const sizePattern = /^\d{3,5}x\d{3,5}$/;
-  if (!sizePattern.test(size)) {
-    errors.push('size must follow WIDTHxHEIGHT');
+  if (typeof size !== 'string' || !allowedSizes.includes(size)) {
+    errors.push(`size must be one of ${allowedSizes.join(', ')}`);
   }
   const secondsNumber = Number(seconds);
   if (!Number.isFinite(secondsNumber) || secondsNumber <= 0 || secondsNumber > 120) {


### PR DESCRIPTION
## Summary
- limit the frontend resolution dropdown to the API-supported options
- validate requested sizes on the backend against the same allowed list
- document the supported resolutions in the data model example

## Testing
- not run (not requested)

------
https://chatgpt.com/codex/tasks/task_e_68e4e2c454fc8328bac985f30ca9b94a