### PR TITLE
Handle in_progress status across frontend and backend

### DIFF
--- a/README.md
+++ b/README.md
@@ -70,7 +70,7 @@
 `Video`
 - `id`: UUID（自前 ID）。
 - `provider_video_id`: OpenAI の動画 ID。
-- `status`: `queued` / `processing` / `completed` / `failed`。
+- `status`: `queued` / `in_progress` / `completed` / `failed`。
 - `model`: 使用モデル名（既定: `sora-2`）。
 - `prompt`: 生成プロンプト。
 - `seconds`: 生成秒数。必要に応じて外部 API 送信時に `duration` へマッピング。

--- a/public/app.js
+++ b/public/app.js
@@ -97,6 +97,7 @@ function translateStatus(status) {
     case 'queued':
       return 'キュー待ち';
     case 'processing':
+    case 'in_progress':
       return '生成中';
     case 'completed':
       return '完了';
@@ -140,7 +141,7 @@ function renderVideos() {
     const meta = clone.querySelector('.video-meta');
     const playBtn = clone.querySelector('.play-btn');
 
-    clone.classList.remove('queued', 'processing', 'completed', 'failed');
+    clone.classList.remove('queued', 'processing', 'in_progress', 'completed', 'failed');
     clone.classList.add(video.status);
 
     statusIndicator.title = translateStatus(video.status);
@@ -208,7 +209,7 @@ async function refreshStatus(id) {
     if (state.currentVideoId === video.id) {
       updatePlayer(video);
     }
-    if (['queued', 'processing'].includes(video.status)) {
+    if (['queued', 'in_progress'].includes(video.status)) {
       schedulePolling(id);
     } else {
       stopPolling(id);
@@ -250,7 +251,7 @@ async function refreshList() {
     state.videos = new Map(videos.map((video) => [video.id, video]));
     renderVideos();
     videos
-      .filter((video) => ['queued', 'processing'].includes(video.status))
+      .filter((video) => ['queued', 'in_progress'].includes(video.status))
       .forEach((video) => schedulePolling(video.id));
   } catch (error) {
     console.error(error);

--- a/public/styles.css
+++ b/public/styles.css
@@ -229,7 +229,8 @@ button:hover {
   color: #34d399;
 }
 
-.video-card.processing .play-btn {
+.video-card.processing .play-btn,
+.video-card.in_progress .play-btn {
   opacity: 0.4;
   pointer-events: none;
 }

--- a/server.js
+++ b/server.js
@@ -233,7 +233,7 @@ function scheduleStatusPoll(videoId) {
   }
   const poll = async () => {
     const record = videos.get(videoId);
-    if (!record || !['queued', 'processing'].includes(record.status)) {
+    if (!record || !['queued', 'in_progress'].includes(record.status)) {
       pollHandles.delete(videoId);
       return;
     }
@@ -262,7 +262,7 @@ function scheduleStatusPoll(videoId) {
         record.resolution = `${statusResponse.width}x${statusResponse.height}`;
       }
       record.updatedAt = new Date().toISOString();
-      if (!['queued', 'processing'].includes(record.status)) {
+      if (!['queued', 'in_progress'].includes(record.status)) {
         pollHandles.delete(videoId);
         return;
       }


### PR DESCRIPTION
## Summary
- add translate/polling support for the new `in_progress` video status in the client
- treat `in_progress` as an active state in the server-side polling loop
- document the status change and align the loading button styling

## Testing
- not run (not requested)


------
https://chatgpt.com/codex/tasks/task_e_68e4e2e71a38832886406f65ceeaff0a