### PR TITLE
Support multipart uploads for input references

### DIFF
--- a/README.md
+++ b/README.md
@@ -59,6 +59,7 @@
 ### 7.2 バックエンド
 - 推奨エンドポイント:
   - `POST /api/videos`: 動画生成ジョブを作成し、自前 ID を発行。
+    - multipart/form-data で受け付け、`input_reference` は 25MB 以下のバイナリを OpenAI API へストリーミング転送する（サーバーに保存しない）。
   - `GET /api/videos/:id/status`: OpenAI Videos API を参照して進捗・状態を返却。
   - `GET /api/videos/:id/content`: OpenAI のコンテンツエンドポイントへサーバからアクセスし、動画バイナリをストリーミング返却。
 - API キーはバックエンドの環境変数で管理。リクエストごとにヘッダへ挿入。
@@ -76,7 +77,7 @@
 - `seconds`: 生成秒数。必要に応じて外部 API 送信時に `duration` へマッピング。
  - `seconds`: 生成秒数。外部 API にも `seconds` として送信。
 - `size`: 出力解像度（例: `1920x1080`）。
-- `input_reference?`: 参照する画像/動画のメタ情報または格納先（任意）。
+- `input_reference?`: 参照メディアが添付されたかどうかのフラグ。バイナリは保存せずに OpenAI へ転送する。
 - `cost_estimate_usd`: コスト目安（任意）。
 - `created_at`, `updated_at`。
 - `metadata`: JSON（アスペクト比、任意のシード値など）。
@@ -84,7 +85,7 @@
 ## 9. API 契約イメージ
 - **生成開始**
   - リクエスト: `POST /api/videos`
-  - ボディ: `prompt`（必須）, `input_reference`（任意）, `model`（任意・既定: `sora-2`）, `seconds`（任意・既定: 4）, `size`（任意・既定: `720x1280`）。
+  - ボディ: `multipart/form-data`。`prompt`（必須）, `input_reference`（任意・25MB 以下）, `model`（任意・既定: `sora-2`）, `seconds`（任意・既定: 4）, `size`（任意・既定: `720x1280`）。
   - レスポンス: `{ "videoId": string }`
 - **ステータス取得**
   - リクエスト: `GET /api/videos/:id/status`

--- a/package-lock.json
+++ b/package-lock.json
@@ -7,7 +7,29 @@
     "": {
       "name": "sora2-251007-2",
       "version": "1.0.0",
-      "license": "ISC"
+      "license": "ISC",
+      "dependencies": {
+        "busboy": "^1.6.0"
+      }
+    },
+    "node_modules/busboy": {
+      "version": "1.6.0",
+      "resolved": "https://registry.npmjs.org/busboy/-/busboy-1.6.0.tgz",
+      "integrity": "sha512-8SFQbg/0hQ9xy3UNTB0YEnsNBbWfhf7RtnzpL7TkBiTBRfrQ9Fxcnz7VJsleJpyp6rVLvXiuORqjlHi5q+PYuA==",
+      "dependencies": {
+        "streamsearch": "^1.1.0"
+      },
+      "engines": {
+        "node": ">=10.16.0"
+      }
+    },
+    "node_modules/streamsearch": {
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/streamsearch/-/streamsearch-1.1.0.tgz",
+      "integrity": "sha512-Mcc5wHehp9aXz1ax6bZUyY5afg9u2rv5cqQI3mRrYkGC8rW2hM02jWuwjtL++LS5qinSyhj2QfLyNsuc+VsExg==",
+      "engines": {
+        "node": ">=10.0.0"
+      }
     }
   }
 }

--- a/package.json
+++ b/package.json
@@ -9,5 +9,8 @@
   "keywords": [],
   "author": "",
   "license": "ISC",
-  "type": "commonjs"
+  "type": "commonjs",
+  "dependencies": {
+    "busboy": "^1.6.0"
+  }
 }

--- a/public/app.js
+++ b/public/app.js
@@ -1,9 +1,8 @@
 const api = {
-  async createVideo(payload) {
+  async createVideo(formData) {
     const response = await fetch('/api/videos', {
       method: 'POST',
-      headers: { 'Content-Type': 'application/json' },
-      body: JSON.stringify(payload),
+      body: formData,
     });
     if (!response.ok) {
       const error = await response.json().catch(() => ({ message: '不明なエラー' }));
@@ -264,15 +263,14 @@ async function handleFormSubmit(event) {
   setMessage('OpenAI へリクエストを送信中…');
   elements.generateBtn.disabled = true;
 
-  const payload = {
-    prompt: elements.prompt.value,
-    model: elements.model.value,
-    size: elements.size.value,
-    seconds: elements.seconds.value,
-  };
+  const formData = new FormData(elements.form);
+  const file = elements.inputReference.files[0];
+  if (!file) {
+    formData.delete('input_reference');
+  }
 
   try {
-    const { videoId, video } = await api.createVideo(payload);
+    const { videoId, video } = await api.createVideo(formData);
     state.videos.set(videoId, video);
     renderVideos();
     schedulePolling(videoId);

--- a/server.js
+++ b/server.js
@@ -4,11 +4,14 @@ const path = require('path');
 const { URL } = require('url');
 const crypto = require('crypto');
 const { Readable } = require('stream');
+const { Blob } = require('buffer');
+const Busboy = require('busboy');
 
 const PORT = process.env.PORT ? Number(process.env.PORT) : 3000;
 const HOST = '0.0.0.0';
 const API_KEY = process.env.OPENAI_API_KEY || '';
 const POLL_INTERVAL_MS = 5000;
+const MAX_REFERENCE_BYTES = 25 * 1024 * 1024; // 25MB
 
 const videos = new Map();
 const pollHandles = new Map();
@@ -48,6 +51,74 @@ async function parseJsonBody(req) {
   });
 }
 
+async function parseMultipartForm(req) {
+  return new Promise((resolve, reject) => {
+    let fileTooLarge = false;
+    const fields = {};
+    let inputReference = null;
+
+    let busboy;
+    try {
+      busboy = Busboy({
+        headers: req.headers,
+        limits: { fileSize: MAX_REFERENCE_BYTES },
+      });
+    } catch (err) {
+      reject(err);
+      return;
+    }
+
+    busboy.on('field', (name, value) => {
+      fields[name] = value;
+    });
+
+    busboy.on('file', (name, file, info) => {
+      if (name !== 'input_reference') {
+        file.resume();
+        return;
+      }
+      if (inputReference) {
+        file.resume();
+        return;
+      }
+
+      const chunks = [];
+      const { filename, mimeType } = info;
+
+      file.on('data', chunk => {
+        chunks.push(chunk);
+      });
+
+      file.on('limit', () => {
+        fileTooLarge = true;
+        file.resume();
+      });
+
+      file.on('end', () => {
+        if (fileTooLarge) {
+          return;
+        }
+        inputReference = {
+          buffer: Buffer.concat(chunks),
+          filename: filename || 'input_reference',
+          mimeType: mimeType || 'application/octet-stream',
+        };
+      });
+    });
+
+    busboy.on('close', () => {
+      if (fileTooLarge) {
+        reject(new Error('input_reference must not exceed 25MB'));
+        return;
+      }
+      resolve({ fields, inputReference });
+    });
+
+    busboy.on('error', reject);
+    req.pipe(busboy);
+  });
+}
+
 function serveStatic(req, res, filePath) {
   const resolvedPath = path.join(__dirname, 'public', filePath);
   fs.stat(resolvedPath, (err, stats) => {
@@ -74,7 +145,7 @@ function serveStatic(req, res, filePath) {
   });
 }
 
-function sanitizeVideoParams(params) {
+function sanitizeVideoParams(params, inputReference) {
   const errors = [];
   // 後方互換のため旧フィールド名を新フィールドへマップ
   const prompt = params.prompt;
@@ -104,12 +175,17 @@ function sanitizeVideoParams(params) {
     errors.push('seconds must be one of 4, 8, 12');
   }
 
+  if (inputReference && inputReference.buffer.length === 0) {
+    errors.push('input_reference file is empty');
+  }
+
   return {
     errors,
     prompt: prompt ? prompt.trim() : '',
     model,
     size,
     seconds,
+    inputReference,
   };
 }
 
@@ -118,20 +194,24 @@ async function callOpenAIVideoCreate(params) {
     throw new Error('OPENAI_API_KEY is not configured');
   }
 
+  const formData = new FormData();
+  formData.set('model', params.model);
+  formData.set('prompt', params.prompt);
+  formData.set('seconds', params.seconds);
+  formData.set('size', params.size);
+  if (params.inputReference) {
+    const blob = new Blob([params.inputReference.buffer], {
+      type: params.inputReference.mimeType || 'application/octet-stream',
+    });
+    formData.append('input_reference', blob, params.inputReference.filename);
+  }
+
   const response = await fetch('https://api.openai.com/v1/videos', {
     method: 'POST',
     headers: {
       'Authorization': `Bearer ${API_KEY}`,
-      'Content-Type': 'application/json',
     },
-    body: JSON.stringify({
-      model: params.model,
-      prompt: params.prompt,
-      // API 仕様に合わせて seconds をそのまま送信
-      seconds: params.seconds,
-      // 解像度は API 仕様に従い "WxH" の size で指定
-      size: params.size,
-    }),
+    body: formData,
   });
 
   if (!response.ok) {
@@ -312,8 +392,25 @@ const server = http.createServer(async (req, res) => {
       }
 
       if (req.method === 'POST' && pathname === '/api/videos') {
-        const body = await parseJsonBody(req);
-        const sanitized = sanitizeVideoParams(body);
+        const contentType = req.headers['content-type'] || '';
+        let rawParams = {};
+        let inputReference = null;
+
+        try {
+          if (contentType.startsWith('multipart/form-data')) {
+            const parsed = await parseMultipartForm(req);
+            rawParams = parsed.fields;
+            inputReference = parsed.inputReference;
+          } else {
+            rawParams = await parseJsonBody(req);
+          }
+        } catch (err) {
+          const status = err.message && err.message.includes('exceed') ? 413 : 400;
+          sendJson(status, { message: err.message || 'Invalid request body' });
+          return;
+        }
+
+        const sanitized = sanitizeVideoParams(rawParams, inputReference);
         if (sanitized.errors.length > 0) {
           sendJson(400, { message: 'Validation error', errors: sanitized.errors });
           return;
@@ -326,6 +423,9 @@ const server = http.createServer(async (req, res) => {
           sendJson(502, { message: err.message });
           return;
         }
+
+        const hadInputReference = Boolean(sanitized.inputReference);
+        sanitized.inputReference = null;
 
         const videoId = crypto.randomUUID();
         const now = new Date().toISOString();
@@ -342,6 +442,7 @@ const server = http.createServer(async (req, res) => {
           // 旧フィールド（後方互換のため併記）
           resolution: sanitized.size,
           durationSeconds: sanitized.seconds,
+          input_reference: hadInputReference,
           createdAt: now,
           updatedAt: now,
           metadata: apiResponse.metadata || {},


### PR DESCRIPTION
## Summary
- add Busboy-based multipart parsing on the server so `input_reference` files are validated, forwarded to OpenAI, and never stored locally
- switch the video creation form to submit `FormData`, only including the optional reference file when provided
- document the multipart workflow, file-size constraint, and storage policy updates in the README

## Testing
- not run (not applicable)


------
https://chatgpt.com/codex/tasks/task_e_68e4d1319e188328bd378b15ced61399